### PR TITLE
Java version of AlgebraicDataTypes

### DIFF
--- a/src/java/src/AlgebraicDataTypes.java
+++ b/src/java/src/AlgebraicDataTypes.java
@@ -1,0 +1,29 @@
+
+import java.util.List;
+
+// Java 19 preview features: sealed classes, records, pattern matching
+//
+// javac --release 19 --enable-preview AlgebraicDataTypes.java
+// java --enable-preview AlgebraicDataTypes
+//
+// see Brian Goetz - https://www.infoq.com/articles/data-oriented-programming-java/
+
+sealed interface ADT {
+    record Person(String eats) implements ADT {}
+    record Robot(String chargesWith) implements ADT {}
+}
+
+public class AlgebraicDataTypes  {
+    void nourishes(ADT x) {
+        switch (x) {
+            // exhaustive
+            case ADT.Person(String eats) -> System.out.println("TRACER person eats: " + eats);
+            case ADT.Robot(String chargesWith) -> System.out.println("TRACER robot charging: " + chargesWith);
+        }
+    }
+
+    public static void main(String [] args) {
+        var adts = new AlgebraicDataTypes();
+        List.of(new ADT.Person("2 apples"), new ADT.Robot("5 volts")).stream().forEach(adts::nourishes);
+    }
+}


### PR DESCRIPTION
In case this is useful, here is a Java version of Scala example for AlgebraicDataTypes, using features from Java 19 (preview).
The example is surprisingly similar to Scala, using sealed classes, records, pattern matching. For details, see [this Brian Goetz article](https://www.infoq.com/articles/data-oriented-programming-java/), "Data Oriented Programming".

* to use, command-line flags:

```
javac --release 19 --enable-preview AlgebraicDataTypes.java
java --enable-preview AlgebraicDataTypes
```